### PR TITLE
feat: exchange rate is deprecated

### DIFF
--- a/src/spaceone/cost_analysis/info/cost_info.py
+++ b/src/spaceone/cost_analysis/info/cost_info.py
@@ -28,6 +28,7 @@ def CostInfo(cost_vo: Cost, minimal=False):
             'original_cost': cost_vo.original_cost,
             'usage_quantity': cost_vo.usage_quantity,
             'usage_unit': cost_vo.usage_unit,
+            'resource_group': cost_vo.resource_group,
             'tags': change_struct_type(cost_vo.tags),
             'additional_info': change_struct_type(cost_vo.additional_info),
             'service_account_id': cost_vo.service_account_id,

--- a/src/spaceone/cost_analysis/manager/cost_manager.py
+++ b/src/spaceone/cost_analysis/manager/cost_manager.py
@@ -42,14 +42,17 @@ class CostManager(BaseManager):
             if original_currency == 'USD':
                 params['usd_cost'] = params['original_cost']
             else:
-                self._load_exchange_rate_map(params['domain_id'])
-
-                rate = self.exchange_rate_map.get(original_currency)
-
-                if rate is None:
-                    raise ERROR_UNSUPPORTED_CURRENCY(supported_currency=list(self.exchange_rate_map.keys()))
-
-                params['usd_cost'] = round(original_cost / rate, 15)
+                params['usd_cost'] = 0
+                # Exchange rate handling is deprecated.
+                # The cost value provided by the individual CSP is used as it is, and the USD cost value provided by the plugin is used as it is.
+                #
+                # self._load_exchange_rate_map(params['domain_id'])
+                # rate = self.exchange_rate_map.get(original_currency)
+                #
+                # if rate is None:
+                #     raise ERROR_UNSUPPORTED_CURRENCY(supported_currency=list(self.exchange_rate_map.keys()))
+                #
+                # params['usd_cost'] = round(original_cost / rate, 15)
 
         params['billed_year'] = params['billed_at'].strftime('%Y')
         params['billed_month'] = params['billed_at'].strftime('%Y-%m')


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
Exchange rate handling in Cost analysis is deprecated.
The cost value provided by the individual CSP is used as it is, and the USD cost value provided by the plugin is used as it is.
