### PR TITLE
Fix append query filter for cost report config 'domain' -> 'domain_id'

### DIFF
--- a/src/spaceone/cost_analysis/service/cost_report_config_service.py
+++ b/src/spaceone/cost_analysis/service/cost_report_config_service.py
@@ -258,7 +258,7 @@ class CostReportConfigService(BaseService):
         permission="cost-analysis:CostReportConfig.read",
         role_types=["DOMAIN_ADMIN", "WORKSPACE_OWNER"],
     )
-    @append_query_filter(["state", "domain", "cost_report_config_id"])
+    @append_query_filter(["state", "domain_id", "cost_report_config_id"])
     @convert_model
     def list(
         self, params: CostReportConfigSearchQueryRequest


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- fix append query filter for cost report config 'domain' -> 'domain_id'
### Known issue