### PR TITLE
Update 'unit' choices in ReportAdjustment model to include 'PERCENT' instead of 'PERCENTAGE'

### DIFF
--- a/src/spaceone/cost_analysis/model/report_adjustment/database.py
+++ b/src/spaceone/cost_analysis/model/report_adjustment/database.py
@@ -6,7 +6,7 @@ from spaceone.core.model.mongo_model import MongoModel
 class ReportAdjustment(MongoModel):
     report_adjustment_id = StringField(max_length=40, generate_id="ra", unique=True)
     name = StringField(max_length=255, required=True)
-    unit = StringField(max_length=20, choices=["FIXED", "PERCENTAGE"], required=True)
+    unit = StringField(max_length=20, choices=["FIXED", "PERCENT"], required=True)
     value = FloatField(required=True)
     description = StringField(default="")
     provider = StringField(max_length=20, required=True)


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- update 'unit' choices in ReportAdjustment model to include 'PERCENT' instead of 'PERCENTAGE'
### Known issue